### PR TITLE
Add optimizer settings UI with NgRx state

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -70,8 +70,8 @@ Min salary used (range input 47000–50000 + number input linked)
 Section: Ownership caps
 Ownership fade (0–100 range)
 (caps by player later; for now just the global fade slider)
-Section: Exposures
-Sim diversity (0–100 range)
+Section: Randomness
+Randomness (0–100 range)
 (per‑player targets later)
 Behavior
 Each control updates store immediately on change.
@@ -143,10 +143,10 @@ optimizer.page.html (right rail section only)
       <input type="range" min="0" max="100" formControlName="ownershipFade"/>
     </section>
 
-    <!-- Exposures -->
+    <!-- Randomness -->
     <section>
-      <h3>Exposures</h3>
-      <label>Sim diversity</label>
+      <h3>Randomness</h3>
+      <label>Randomness</label>
       <input type="range" min="0" max="100" formControlName="simDiversity"/>
     </section>
 

--- a/dfs-sim-ui/src/app/app.config.ts
+++ b/dfs-sim-ui/src/app/app.config.ts
@@ -1,12 +1,16 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideStore } from '@ngrx/store';
 
 import { routes } from './app.routes';
+import { reducer as builderReducer } from './state/builder';
+import { reducer as rulesReducer } from './state/rules';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideStore({ builder: builderReducer, rules: rulesReducer })
   ]
 };

--- a/dfs-sim-ui/src/app/inspector/inspector.ts
+++ b/dfs-sim-ui/src/app/inspector/inspector.ts
@@ -1,21 +1,16 @@
 import { Component, signal } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { OptimizerSettingsComponent } from './optimizer-settings.component';
 
 @Component({
   selector: 'app-inspector',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, OptimizerSettingsComponent],
   template: `
     <div class="inspector-wrap">
       @if (activeTool() === 'optimizer') {
-        <section class="section">
-          <h3>Optimizer Settings</h3>
-          <div class="field"><span class="label">Lineup rules</span><span class="value">Placeholder</span></div>
-          <div class="field"><span class="label">Salary min/max</span><span class="value">Placeholder</span></div>
-          <div class="field"><span class="label">Ownership caps</span><span class="value">Placeholder</span></div>
-          <div class="field"><span class="label">Exposures</span><span class="value">Placeholder</span></div>
-        </section>
+        <app-optimizer-settings></app-optimizer-settings>
       } @else if (activeTool() === 'simulations') {
         <section class="section">
           <h3>Simulations Settings</h3>

--- a/dfs-sim-ui/src/app/inspector/optimizer-settings.component.html
+++ b/dfs-sim-ui/src/app/inspector/optimizer-settings.component.html
@@ -36,14 +36,21 @@
   <!-- Ownership -->
   <section>
     <h3>Ownership caps</h3>
-    <label>Ownership fade</label>
+    <label class="value-label">
+      <span>Ownership fade</span>
+      <span>{{ form.value.ownershipFade }}%</span>
+    </label>
     <input type="range" min="0" max="100" formControlName="ownershipFade" />
   </section>
 
-  <!-- Exposures -->
+  <!-- Randomness -->
   <section>
-    <h3>Exposures</h3>
-    <label>Sim diversity</label>
+    <h3>Randomness</h3>
+    <label class="value-label">
+      <span>Randomness</span>
+      <span>{{ form.value.simDiversity }}</span>
+    </label>
     <input type="range" min="0" max="100" formControlName="simDiversity" />
+    <p class="hint">Higher values increase lineup diversity.</p>
   </section>
 </form>

--- a/dfs-sim-ui/src/app/inspector/optimizer-settings.component.html
+++ b/dfs-sim-ui/src/app/inspector/optimizer-settings.component.html
@@ -1,0 +1,49 @@
+<form [formGroup]="form" class="settings">
+  <!-- Lineup Rules -->
+  <section>
+    <h3>Lineup rules</h3>
+
+    <label>Min uniques</label>
+    <app-segmented formControlName="minUniques" [options]="[1,2,3]"></app-segmented>
+    <p class="hint">Minimum different players across generated lineups.</p>
+
+    <label>Max per team</label>
+    <input type="number" min="1" max="8" placeholder="Unlimited" formControlName="maxPerTeam" />
+    <p class="hint">Leave blank for no cap.</p>
+
+    <label>Stacking</label>
+    <select formControlName="stackType">
+      <option value="none">None</option>
+      <option value="team">Team</option>
+      <option value="game">Game</option>
+    </select>
+
+    <label>Stack size</label>
+    <input type="number" min="2" max="4" formControlName="stackSize" [disabled]="form.value.stackType==='none'" />
+  </section>
+
+  <!-- Salary -->
+  <section>
+    <h3>Salary min/max</h3>
+    <label>Min salary used</label>
+    <input type="range" min="47000" max="50000" step="100" formControlName="salaryMinUsed" />
+    <div class="row">
+      <input type="number" min="47000" max="50000" step="100" formControlName="salaryMinUsed" />
+      <span class="hint">DK cap: $50,000</span>
+    </div>
+  </section>
+
+  <!-- Ownership -->
+  <section>
+    <h3>Ownership caps</h3>
+    <label>Ownership fade</label>
+    <input type="range" min="0" max="100" formControlName="ownershipFade" />
+  </section>
+
+  <!-- Exposures -->
+  <section>
+    <h3>Exposures</h3>
+    <label>Sim diversity</label>
+    <input type="range" min="0" max="100" formControlName="simDiversity" />
+  </section>
+</form>

--- a/dfs-sim-ui/src/app/inspector/optimizer-settings.component.scss
+++ b/dfs-sim-ui/src/app/inspector/optimizer-settings.component.scss
@@ -2,6 +2,7 @@
 section + section { margin-top: 18px; padding-top: 12px; border-top: 1px solid var(--border); }
 h3 { font-size: var(--fs-14); margin: 0 0 8px; opacity: .9; }
 label { display: block; font-size: var(--fs-12); opacity: .85; margin: 8px 0 4px; }
+.value-label { display: flex; justify-content: space-between; }
 .hint { color: var(--subtle); font-size: var(--fs-12); margin-top: 4px; }
 .row { display: flex; align-items: center; gap: var(--gap-2); }
 input, select { width: 100%; background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; }

--- a/dfs-sim-ui/src/app/inspector/optimizer-settings.component.scss
+++ b/dfs-sim-ui/src/app/inspector/optimizer-settings.component.scss
@@ -1,0 +1,8 @@
+.settings { padding: var(--gap-3); color: var(--text); }
+section + section { margin-top: 18px; padding-top: 12px; border-top: 1px solid var(--border); }
+h3 { font-size: var(--fs-14); margin: 0 0 8px; opacity: .9; }
+label { display: block; font-size: var(--fs-12); opacity: .85; margin: 8px 0 4px; }
+.hint { color: var(--subtle); font-size: var(--fs-12); margin-top: 4px; }
+.row { display: flex; align-items: center; gap: var(--gap-2); }
+input, select { width: 100%; background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; }
+input[type="range"] { width: 100%; background: transparent; }

--- a/dfs-sim-ui/src/app/inspector/optimizer-settings.component.ts
+++ b/dfs-sim-ui/src/app/inspector/optimizer-settings.component.ts
@@ -1,0 +1,73 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { Store } from '@ngrx/store';
+import * as Rules from '../state/rules';
+import * as Builder from '../state/builder';
+import { SegmentedComponent } from '../ui/controls/segmented/segmented.component';
+
+@Component({
+  selector: 'app-optimizer-settings',
+  standalone: true,
+  imports: [ReactiveFormsModule, SegmentedComponent],
+  templateUrl: './optimizer-settings.component.html',
+  styleUrls: ['./optimizer-settings.component.scss']
+})
+export class OptimizerSettingsComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private store = inject(Store);
+
+  form = this.fb.group({
+    minUniques: 1,
+    maxPerTeam: null as number | null,
+    stackType: 'none' as 'none' | 'team' | 'game',
+    stackSize: null as number | null,
+    lineupCount: 20,
+    salaryMinUsed: 49500,
+    correlation: 50,
+    ownershipFade: 30,
+    simDiversity: 50,
+  });
+
+  ngOnInit(): void {
+    this.store.select(Rules.selectRules).subscribe(r => {
+      this.form.patchValue({
+        minUniques: r.minUniques,
+        maxPerTeam: r.maxPerTeam ?? null,
+        stackType: r.stackType ?? 'none',
+        stackSize: r.stackSize ?? null,
+      }, { emitEvent: false });
+    });
+    this.store.select(Builder.selectBuilder).subscribe(b => {
+      this.form.patchValue({
+        lineupCount: b.lineupCount,
+        salaryMinUsed: b.salaryMinUsed,
+        correlation: b.correlation,
+        ownershipFade: b.ownershipFade,
+        simDiversity: b.simDiversity,
+      }, { emitEvent: false });
+    });
+
+    this.form.get('minUniques')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Rules.setMinUniques({ value: Number(v) }))
+    );
+    this.form.get('maxPerTeam')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Rules.setMaxPerTeam({ value: v == null ? null : Number(v) }))
+    );
+    this.form.get('stackType')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Rules.setStackType({ value: v as any }))
+    );
+    this.form.get('stackSize')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Rules.setStackSize({ value: v ? Number(v) : null }))
+    );
+
+    this.form.get('salaryMinUsed')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Builder.setSalaryMinUsed({ value: Number(v) }))
+    );
+    this.form.get('ownershipFade')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Builder.setOwnershipFade({ value: Number(v) }))
+    );
+    this.form.get('simDiversity')!.valueChanges.subscribe(v =>
+      this.store.dispatch(Builder.setSimDiversity({ value: Number(v) }))
+    );
+  }
+}

--- a/dfs-sim-ui/src/app/state/builder/builder.actions.ts
+++ b/dfs-sim-ui/src/app/state/builder/builder.actions.ts
@@ -1,0 +1,7 @@
+import { createAction, props } from '@ngrx/store';
+
+export const setLineupCount = createAction('[Builder] Set Lineup Count', props<{ value: number }>());
+export const setSalaryMinUsed = createAction('[Builder] Set Salary Min Used', props<{ value: number }>());
+export const setCorrelation = createAction('[Builder] Set Correlation', props<{ value: number }>());
+export const setOwnershipFade = createAction('[Builder] Set Ownership Fade', props<{ value: number }>());
+export const setSimDiversity = createAction('[Builder] Set Sim Diversity', props<{ value: number }>());

--- a/dfs-sim-ui/src/app/state/builder/builder.reducer.ts
+++ b/dfs-sim-ui/src/app/state/builder/builder.reducer.ts
@@ -1,0 +1,27 @@
+import { createReducer, on } from '@ngrx/store';
+import * as BuilderActions from './builder.actions';
+
+export interface BuilderState {
+  lineupCount: number; // 1-150
+  salaryMinUsed: number; // 0..50000
+  correlation: number; // 0..100
+  ownershipFade: number; // 0..100
+  simDiversity: number; // 0..100
+}
+
+export const initialBuilder: BuilderState = {
+  lineupCount: 20,
+  salaryMinUsed: 49500,
+  correlation: 50,
+  ownershipFade: 30,
+  simDiversity: 50,
+};
+
+export const reducer = createReducer(
+  initialBuilder,
+  on(BuilderActions.setLineupCount, (state, { value }) => ({ ...state, lineupCount: value })),
+  on(BuilderActions.setSalaryMinUsed, (state, { value }) => ({ ...state, salaryMinUsed: value })),
+  on(BuilderActions.setCorrelation, (state, { value }) => ({ ...state, correlation: value })),
+  on(BuilderActions.setOwnershipFade, (state, { value }) => ({ ...state, ownershipFade: value })),
+  on(BuilderActions.setSimDiversity, (state, { value }) => ({ ...state, simDiversity: value })),
+);

--- a/dfs-sim-ui/src/app/state/builder/builder.selectors.ts
+++ b/dfs-sim-ui/src/app/state/builder/builder.selectors.ts
@@ -1,0 +1,10 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { BuilderState } from './builder.reducer';
+
+export const selectBuilder = createFeatureSelector<BuilderState>('builder');
+
+export const selectLineupCount = createSelector(selectBuilder, s => s.lineupCount);
+export const selectSalaryMinUsed = createSelector(selectBuilder, s => s.salaryMinUsed);
+export const selectCorrelation = createSelector(selectBuilder, s => s.correlation);
+export const selectOwnershipFade = createSelector(selectBuilder, s => s.ownershipFade);
+export const selectSimDiversity = createSelector(selectBuilder, s => s.simDiversity);

--- a/dfs-sim-ui/src/app/state/builder/index.ts
+++ b/dfs-sim-ui/src/app/state/builder/index.ts
@@ -1,0 +1,3 @@
+export * from './builder.actions';
+export * from './builder.reducer';
+export * from './builder.selectors';

--- a/dfs-sim-ui/src/app/state/rules/index.ts
+++ b/dfs-sim-ui/src/app/state/rules/index.ts
@@ -1,0 +1,3 @@
+export * from './rules.actions';
+export * from './rules.reducer';
+export * from './rules.selectors';

--- a/dfs-sim-ui/src/app/state/rules/rules.actions.ts
+++ b/dfs-sim-ui/src/app/state/rules/rules.actions.ts
@@ -1,0 +1,6 @@
+import { createAction, props } from '@ngrx/store';
+
+export const setMinUniques = createAction('[Rules] Set Min Uniques', props<{ value: number }>());
+export const setMaxPerTeam = createAction('[Rules] Set Max Per Team', props<{ value: number | null }>());
+export const setStackType = createAction('[Rules] Set Stack Type', props<{ value: 'none' | 'team' | 'game' }>());
+export const setStackSize = createAction('[Rules] Set Stack Size', props<{ value: number | null }>());

--- a/dfs-sim-ui/src/app/state/rules/rules.reducer.ts
+++ b/dfs-sim-ui/src/app/state/rules/rules.reducer.ts
@@ -1,0 +1,24 @@
+import { createReducer, on } from '@ngrx/store';
+import * as RulesActions from './rules.actions';
+
+export interface RulesState {
+  minUniques: number; // 1–3
+  maxPerTeam?: number | null; // null = unlimited
+  stackType?: 'none' | 'team' | 'game';
+  stackSize?: number | null; // e.g., 2 or 3 if enabled
+}
+
+export const initialRules: RulesState = {
+  minUniques: 1,
+  maxPerTeam: null,
+  stackType: 'none',
+  stackSize: null,
+};
+
+export const reducer = createReducer(
+  initialRules,
+  on(RulesActions.setMinUniques, (state, { value }) => ({ ...state, minUniques: value })),
+  on(RulesActions.setMaxPerTeam, (state, { value }) => ({ ...state, maxPerTeam: value })),
+  on(RulesActions.setStackType, (state, { value }) => ({ ...state, stackType: value })),
+  on(RulesActions.setStackSize, (state, { value }) => ({ ...state, stackSize: value })),
+);

--- a/dfs-sim-ui/src/app/state/rules/rules.selectors.ts
+++ b/dfs-sim-ui/src/app/state/rules/rules.selectors.ts
@@ -1,0 +1,9 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { RulesState } from './rules.reducer';
+
+export const selectRules = createFeatureSelector<RulesState>('rules');
+
+export const selectMinUniques = createSelector(selectRules, s => s.minUniques);
+export const selectMaxPerTeam = createSelector(selectRules, s => s.maxPerTeam);
+export const selectStackType = createSelector(selectRules, s => s.stackType);
+export const selectStackSize = createSelector(selectRules, s => s.stackSize);

--- a/dfs-sim-ui/src/app/ui/controls/segmented/segmented.component.ts
+++ b/dfs-sim-ui/src/app/ui/controls/segmented/segmented.component.ts
@@ -1,0 +1,48 @@
+import { Component, Input, forwardRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-segmented',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="segmented">
+      <button *ngFor="let opt of options" type="button" (click)="select(opt)" [class.active]="opt===value">{{opt}}</button>
+    </div>
+  `,
+  styles: [`
+    .segmented { display: flex; gap: 4px; }
+    .segmented button { flex: 1; padding: 6px 8px; border: 1px solid var(--border); background: var(--panel); color: var(--text); cursor: pointer; }
+    .segmented button.active { background: var(--muted); }
+  `],
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => SegmentedComponent),
+    multi: true,
+  }]
+})
+export class SegmentedComponent implements ControlValueAccessor {
+  @Input() options: any[] = [];
+  value: any;
+  private onChange: any = () => {};
+  private onTouched: any = () => {};
+
+  select(opt: any) {
+    this.value = opt;
+    this.onChange(opt);
+    this.onTouched();
+  }
+
+  writeValue(value: any): void {
+    this.value = value;
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+}


### PR DESCRIPTION
## Summary
- Implement rules and builder NgRx slices with initial state and actions
- Add segmented control and reactive form for optimizer settings right rail
- Wire form controls to store and provide reducers in app config

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7dd5b5eac832c972826d664bbb00d