### PR TITLE
feat: add player models and CSV parsing services

### DIFF
--- a/dfs-sim-ui/angular.json
+++ b/dfs-sim-ui/angular.json
@@ -25,12 +25,7 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets",
-              {
-                "glob": "**/*",
-                "input": "src/assets/dk_data",
-                "output": "/dk_data/"
-              }
+              "src/assets"
             ],
             "styles": [
               "src/styles.scss"

--- a/dfs-sim-ui/src/app/core/models/contest.model.ts
+++ b/dfs-sim-ui/src/app/core/models/contest.model.ts
@@ -1,0 +1,12 @@
+export interface PayoutBucket {
+  from: number;
+  to: number;
+  amount: number;
+}
+
+export interface ContestStructure {
+  id: string;
+  entries: number;
+  buckets: PayoutBucket[];
+  minCash?: number | null;
+}

--- a/dfs-sim-ui/src/app/core/models/player.model.ts
+++ b/dfs-sim-ui/src/app/core/models/player.model.ts
@@ -1,0 +1,22 @@
+export type PlayerPosition =
+  | 'PG'
+  | 'SG'
+  | 'SF'
+  | 'PF'
+  | 'C'
+  | 'G'
+  | 'F'
+  | 'UTIL';
+
+export interface Player {
+  id: string;
+  name: string;
+  positions: PlayerPosition[];
+  team: string;
+  salary: number;
+  minutes?: number | null;
+  fpts?: number | null;
+  ownership?: number | null;
+  stddev?: number | null;
+  fieldFpts?: number | null;
+}

--- a/dfs-sim-ui/src/app/core/services/contest-csv.service.ts
+++ b/dfs-sim-ui/src/app/core/services/contest-csv.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { CsvService } from './csv.service';
+import { ContestStructure, PayoutBucket } from '../models/contest.model';
+
+function parseNumber(val: unknown): number | null {
+  if (val === null || val === undefined || val === '') return null;
+  const num = Number(String(val).replace(/[$,%]/g, '').trim());
+  return isNaN(num) ? null : num;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ContestCsvService {
+  constructor(private csv: CsvService) {}
+
+  async load(file: File | string = '/assets/dk_data/contest_structure.csv'): Promise<ContestStructure[]> {
+    const rows = await this.csv.parse<Record<string, unknown>>(file);
+    const grouped: Record<string, { entries: number[]; buckets: PayoutBucket[] }> = {};
+
+    for (const r of rows) {
+      const id = (r['contest_id'] ?? r['Contest'] ?? r['Name'] ?? '') as string;
+      if (!id) continue;
+      const entries = parseNumber(r['entries'] ?? r['Entries']);
+      const from = parseNumber(r['place_from'] ?? r['from'] ?? r['PlaceFrom']);
+      const to = parseNumber(r['place_to'] ?? r['to'] ?? r['PlaceTo']);
+      const amount = parseNumber(r['amount'] ?? r['payout'] ?? r['Amount'] ?? r['Payout']);
+      if (from == null || to == null || amount == null) continue;
+
+      if (!grouped[id]) {
+        grouped[id] = { entries: [], buckets: [] };
+      }
+      if (entries != null) grouped[id].entries.push(entries);
+      grouped[id].buckets.push({ from, to, amount });
+    }
+
+    const contests: ContestStructure[] = [];
+    for (const [id, data] of Object.entries(grouped)) {
+      data.buckets.sort((a, b) => a.from - b.from);
+      const entries = data.entries.length ? Math.max(...data.entries) : 0;
+      const contest: ContestStructure = {
+        id,
+        entries,
+        buckets: data.buckets,
+        minCash: data.buckets[0]?.amount ?? null,
+      };
+      contests.push(contest);
+    }
+    return contests;
+  }
+}

--- a/dfs-sim-ui/src/app/core/services/csv.service.ts
+++ b/dfs-sim-ui/src/app/core/services/csv.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import Papa from 'papaparse';
+
+type ParseResult<T> = { data: T[] };
+
+@Injectable({ providedIn: 'root' })
+export class CsvService {
+  parse<T>(input: File | string): Promise<T[]> {
+    return new Promise((resolve, reject) => {
+      Papa.parse(input, {
+        header: true,
+        dynamicTyping: true,
+        skipEmptyLines: true,
+        complete: (result: ParseResult<T>) => resolve(result.data as T[]),
+        error: (err: unknown) => reject(err as Error)
+      });
+    });
+  }
+}

--- a/dfs-sim-ui/src/app/core/services/player-csv.service.spec.ts
+++ b/dfs-sim-ui/src/app/core/services/player-csv.service.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { PlayerCsvService } from './player-csv.service';
+import { PlayerIdsCsvService } from './player-ids-csv.service';
+
+const SAMPLE = `ID,Name,Position,Team,Salary,Minutes,Fpts,own%,stddev,fieldFpts\n1,John Doe,PG,LAL,$5000,30,35,15%,5,40`;
+
+describe('PlayerCsvService', () => {
+  let service: PlayerCsvService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: PlayerIdsCsvService, useValue: { load: () => Promise.resolve({}) } }],
+    });
+    service = TestBed.inject(PlayerCsvService);
+  });
+
+  it('parses players from CSV', async () => {
+    const players = await service.parse(SAMPLE);
+    expect(players.length).toBe(1);
+    const p = players[0];
+    expect(p.name).toBe('John Doe');
+    expect(p.positions).toEqual(['PG']);
+    expect(p.salary).toBe(5000);
+    expect(p.ownership).toBeCloseTo(0.15, 5);
+  });
+});

--- a/dfs-sim-ui/src/app/core/services/player-csv.service.ts
+++ b/dfs-sim-ui/src/app/core/services/player-csv.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+import { CsvService } from './csv.service';
+import { Player, PlayerPosition } from '../models/player.model';
+import { PlayerIdsCsvService } from './player-ids-csv.service';
+
+const POSITIONS: PlayerPosition[] = ['PG', 'SG', 'SF', 'PF', 'C', 'G', 'F', 'UTIL'];
+
+function parseNumber(val: unknown): number | null {
+  if (val === null || val === undefined || val === '') return null;
+  const num = Number(String(val).replace(/[$,%]/g, ''));
+  return isNaN(num) ? null : num;
+}
+
+function parsePositions(raw: unknown): PlayerPosition[] {
+  if (!raw) return [];
+  const parts = String(raw)
+    .split(/[/,]/)
+    .map(p => p.trim().toUpperCase())
+    .filter(p => POSITIONS.includes(p as PlayerPosition));
+  return Array.from(new Set(parts)) as PlayerPosition[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class PlayerCsvService {
+  constructor(private csv: CsvService, private ids: PlayerIdsCsvService) {}
+
+  async parse(file: File | string = '/assets/dk_data/projections.csv'): Promise<Player[]> {
+    const [rows, idMap] = await Promise.all([
+      this.csv.parse<Record<string, unknown>>(file),
+      this.ids.load(),
+    ]);
+
+    const players: Player[] = [];
+    for (const r of rows) {
+      const name = (r['Name'] ?? r['name'] ?? '') as string;
+      const positions = parsePositions(r['Position'] ?? r['position']);
+      const team = (r['Team'] ?? r['team'] ?? '') as string;
+      const salary = parseNumber(r['Salary'] ?? r['salary']);
+      if (!name || !team || !salary || !positions.length) continue;
+
+      const player: Player = {
+        id: (r['ID'] ?? r['id'] ?? '').toString(),
+        name,
+        positions,
+        team,
+        salary,
+        minutes: parseNumber(r['Minutes']) ?? null,
+        fpts: parseNumber(r['Fpts']) ?? null,
+        ownership: (() => {
+          const own = parseNumber(r['own%'] ?? r['Ownership']);
+          if (own == null) return null;
+          return own > 1 ? own / 100 : own;
+        })(),
+        stddev: parseNumber(r['stddev']) ?? null,
+        fieldFpts: parseNumber(r['fieldFpts']) ?? null,
+      };
+
+      if (!player.id) {
+        const key = name.toLowerCase().trim().replace(/\s+/g, ' ');
+        const id = idMap[key];
+        if (id) player.id = id;
+      }
+
+      players.push(player);
+    }
+
+    return players;
+  }
+}

--- a/dfs-sim-ui/src/app/core/services/player-ids-csv.service.ts
+++ b/dfs-sim-ui/src/app/core/services/player-ids-csv.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { CsvService } from './csv.service';
+
+function normalize(name: string): string {
+  return name.toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+@Injectable({ providedIn: 'root' })
+export class PlayerIdsCsvService {
+  constructor(private csv: CsvService) {}
+
+  async load(file: File | string = '/assets/dk_data/player_ids.csv'): Promise<Record<string, string>> {
+    const rows = await this.csv.parse<Record<string, unknown>>(file);
+    const map: Record<string, string> = {};
+    for (const r of rows) {
+      const name = (r['name'] ?? r['Name'] ?? r['player'] ?? r['Player'] ?? '') as string;
+      const id = (r['id'] ?? r['ID'] ?? r['dk_id'] ?? r['DKID'] ?? r['player_id'] ?? '') as string;
+      if (!name || !id) continue;
+      map[normalize(name)] = id.toString();
+    }
+    return map;
+  }
+}

--- a/dfs-sim-ui/src/app/pages.ts
+++ b/dfs-sim-ui/src/app/pages.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { PlayerCsvService } from './core/services/player-csv.service';
+import { ContestCsvService } from './core/services/contest-csv.service';
 
 /* Optimizer */
 @Component({
@@ -31,7 +33,20 @@ import { CommonModule } from '@angular/common';
     .btn:hover { background: var(--panel); }
   `]
 })
-export class OptimizerPage {}
+export class OptimizerPage implements OnInit {
+  private players = inject(PlayerCsvService);
+  private contestsSvc = inject(ContestCsvService);
+
+  async ngOnInit(): Promise<void> {
+    const [players, contests] = await Promise.all([
+      this.players.parse(),
+      this.contestsSvc.load(),
+    ]);
+    console.log('[Task2] players:', players.length);
+    console.table(players.slice(0, 10));
+    console.log('[Task2] contests:', contests.length, contests[0]);
+  }
+}
 
 /* Simulations */
 @Component({

--- a/dfs-sim-ui/src/assets/dk_data/contest_structure.csv
+++ b/dfs-sim-ui/src/assets/dk_data/contest_structure.csv
@@ -1,0 +1,4 @@
+contest_id,entries,place_from,place_to,amount
+mini,1000,1,1,10000
+mini,1000,2,10,100
+mini,1000,11,100,10

--- a/dfs-sim-ui/src/assets/dk_data/player_ids.csv
+++ b/dfs-sim-ui/src/assets/dk_data/player_ids.csv
@@ -1,0 +1,3 @@
+name,dk_id
+LeBron James,12345
+Stephen Curry,23456

--- a/dfs-sim-ui/src/assets/dk_data/projections.csv
+++ b/dfs-sim-ui/src/assets/dk_data/projections.csv
@@ -1,0 +1,3 @@
+Name,Position,Team,Salary,Minutes,Fpts,own%,stddev,fieldFpts,ID
+LeBron James,SF/PF,LAL,$10000,35,50,20%,5,48,12345
+Stephen Curry,PG,GSW,9900,34,48,15,4,45,

--- a/dfs-sim-ui/src/typings.d.ts
+++ b/dfs-sim-ui/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'papaparse';

--- a/dk_data/.gitignore
+++ b/dk_data/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
## Summary
- model player positions and optional stats
- add CSV services for player IDs and contest structures
- enrich PlayerCsvService with normalization, ID lookup, and Optimizer logging
- serve DraftKings CSV data from Angular assets and update services to /assets/dk_data paths

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a870ff1680832ca3dfe702d31a173c